### PR TITLE
fixing syntax issue for ruby sass converter

### DIFF
--- a/scss/components/grid.scss
+++ b/scss/components/grid.scss
@@ -32,7 +32,7 @@ $breakpoint: (
     @media all and (min-width: $val) {
         @for $i from 1 through $grid-columns {
             .col-#{$key}-#{$i} {
-                width: 100 / $grid-columns * $i + %;
+                width: 100% / $grid-columns * $i;
             }
         }
     }


### PR DESCRIPTION
Error: Invalid CSS after "...columns * $i + ": expected expression (e.g. 1px, bold), was "%;"
        on line 35 of scss\components\grid.scss